### PR TITLE
Turn off the bastion instance now that the blog post is up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-github-actions-oidc
 
-This repo is a companion to our blog on setting up a Terraform pipeline with GitHub Actions and GitHub OIDC for AWS.
+This repo is a companion to our blog post: [Set Up a Terraform Pipeline with GitHub Actions and GitHub OIDC for AWS](https://blog.symops.com/2022/04/14/terraform-pipeline-with-github-actions-and-github-oidc-for-aws/).
 
 ## Repo layout
 

--- a/environments/prod/blog.auto.tfvars
+++ b/environments/prod/blog.auto.tfvars
@@ -1,6 +1,1 @@
-bastion_enabled = true
-bastion_private_subnet_ids = [
-  "subnet-095c3a86def7689cd",
-  "subnet-094f9efdc8cb28742",
-]
-bastion_vpc_id = "vpc-050e7962459e9874c"
+bastion_enabled = false


### PR DESCRIPTION
We don't need to leave this infra running now that we've got the examples set up in our post.